### PR TITLE
dirty fix: Tierstimmen-Datenset mit id ausgzeichnet

### DIFF
--- a/daten/index.html
+++ b/daten/index.html
@@ -2598,7 +2598,8 @@ https://commons.wikimedia.org/wiki/Category:Prints_by_Hermann_Struck?uselang=de"
                         </dl>
                     </div>
                 </div>
-                <div class="data-point">
+		<!-- 2017-04-13 SB added id="tierstimmen" below as a quick link fix -->
+                <div id="tierstimmen" class="data-point">
                     <div class="data-media">
                     </div>
                     <div class="data-content">


### PR DESCRIPTION
Um das Tierstimmen-Datenset des Museums für Naturkunde direkt verlinkbar zu machen, habe ich dem entsprechenden <div> die id="tierstimmen" gegeben.