### PR TITLE
fix missing double quote in link to DNB data

### DIFF
--- a/daten/index.html
+++ b/daten/index.html
@@ -761,7 +761,7 @@ js: daten.js
                             </dd>
                             <dt>Links</dt>
                             <dd>
-                                <a href= http://files.dnb.de/CodingDaVinci/Coding_da_Vinci_Titel.zip">Metadaten</a><br/>
+                                <a href="http://files.dnb.de/CodingDaVinci/Coding_da_Vinci_Titel.zip">Metadaten</a><br/>
                                 <a href="{{ site.baseurl }}downloads/datenpraesentation-2015/dnb-wki.pdf">
                                     Datenpräsentation</a>
                             </dd>


### PR DESCRIPTION
digiS (M. Klindt) reported broken Link to DNB data. Added missing double quote in href.