### PR TITLE
Please change the date of the Ost awards show to June 16th, 2018

### DIFF
--- a/events/ost/index.html
+++ b/events/ost/index.html
@@ -53,7 +53,7 @@ header_events: true
 		       Preisverleihung
 		     </h3>
 		     <p class="steps-description">
-				19. Juni 2018</br>
+				16. Juni 2018</br>
 				Universitätsbibliothek Leipzig</p>
 		   </div>
 		 </div>


### PR DESCRIPTION
The awards show of the Ost event will be on saturday June 16h, 2018. I changed it back to that date on the Ost events page.