### PR TITLE
erstmal den rm-onboarding-post verstecken

### DIFF
--- a/news/_posts/2018-06-20-cdv-rm-onboarding.md
+++ b/news/_posts/2018-06-20-cdv-rm-onboarding.md
@@ -1,5 +1,5 @@
 ---
-date: '2018-06-20 10:00'
+date: '2019-06-20 10:00'
 author: Elisabeth Klein
 layout: post
 published: true


### PR DESCRIPTION
 wenn alles fertig ist, kann einfach das Datum im news-header wieder richtig gesetzt werden