### PR TITLE
Unify CC * 4.0 spelling variants

### DIFF
--- a/daten/index.html
+++ b/daten/index.html
@@ -4879,7 +4879,7 @@ http://echo.mpiwg-berlin.mpg.de/ECHOdocuView?url=/mpiwg/online/permanent/archime
                 <br />
 
                 <span class="label label-danger">
-                  CC-BY-SA 4.0 International
+                  CC-BY-SA 4.0
                 </span>
                 Mediendateien
                 <br />
@@ -12473,7 +12473,7 @@ http://www.zoosphere.net/api/v1/sequences?offset=&lt;page&gt;&count=&lt;number o
                 <br />
 
                 <span class="label label-danger">
-                  CC-BY-SA 4.0 International
+                  CC-BY-SA 4.0
                 </span>
                 Mediendateien
                 <br />
@@ -13231,7 +13231,7 @@ http://www.zoosphere.net/api/v1/sequences?offset=&lt;page&gt;&count=&lt;number o
                 Metadaten
                 <br />
 
-                <span class="label label-danger">CC-BY 4.0 International</span>
+                <span class="label label-danger">CC-BY 4.0</span>
                 Mediendateien
                 <br />
               </dd>
@@ -14326,11 +14326,11 @@ http://www.zoosphere.net/api/v1/sequences?offset=&lt;page&gt;&count=&lt;number o
 
               <dt>Lizenz</dt>
               <dd class="data-license">
-                <span class="label label-danger">CC-BY 4.0 International</span>
+                <span class="label label-danger">CC-BY 4.0</span>
                 Metadaten
                 <br />
 
-                <span class="label label-danger">CC-BY 4.0 International</span>
+                <span class="label label-danger">CC-BY 4.0</span>
                 Mediendateien
                 <br />
               </dd>
@@ -14417,7 +14417,7 @@ http://www.zoosphere.net/api/v1/sequences?offset=&lt;page&gt;&count=&lt;number o
 
               <dt>Lizenz</dt>
               <dd class="data-license">
-                <span class="label label-danger">CC-BY 4.0 International</span>
+                <span class="label label-danger">CC-BY 4.0</span>
                 Metadaten
                 <br />
 
@@ -14719,7 +14719,7 @@ http://www.zoosphere.net/api/v1/sequences?offset=&lt;page&gt;&count=&lt;number o
 
               <dt>Lizenz</dt>
               <dd class="data-license">
-                <span class="label label-danger">CC-BY 4.0 International</span>
+                <span class="label label-danger">CC-BY 4.0</span>
                 Metadaten
                 <br />
               </dd>
@@ -14879,7 +14879,7 @@ http://www.zoosphere.net/api/v1/sequences?offset=&lt;page&gt;&count=&lt;number o
                 <br />
 
                 <span class="label label-danger">
-                  CC-BY-SA 4.0 International
+                  CC-BY-SA 4.0
                 </span>
                 Mediendateien
                 <br />


### PR DESCRIPTION
"CC-BY-SA 4.0" and "CC-BY-SA 4.0 International" (aka "Creative Commons Attribution-ShareAlike 4.0 International") are actually the very same licence, so let's use the same name everywhere; c.f. https://creativecommons.org/licenses/by-sa/4.0/