### PR TITLE
Improved filters and sharing urls

### DIFF
--- a/daten/index.html
+++ b/daten/index.html
@@ -18,6 +18,13 @@ js: daten.js
 		</div>
 -->
       <div class="nav-filter">
+        <div class="nav-filter-toggle" data-filter="year">
+          Event
+          <span class="caret"></span>
+        </div>
+        <div class="nav-filter-entries nav-filter-years visible"></div>
+      </div>
+      <div class="nav-filter">
         <div class="nav-filter-toggle" data-filter="types">
           Schnittstellen/Dateiformate
           <span class="caret"></span>
@@ -30,13 +37,6 @@ js: daten.js
           <span class="caret"></span>
         </div>
         <div class="nav-filter-entries nav-filter-licenses visible"></div>
-      </div>
-      <div class="nav-filter">
-        <div class="nav-filter-toggle" data-filter="year">
-          Event
-          <span class="caret"></span>
-        </div>
-        <div class="nav-filter-entries nav-filter-years visible"></div>
       </div>
       <!--
             <div class="nav-filter">

--- a/js/daten.js
+++ b/js/daten.js
@@ -109,7 +109,6 @@ $(document).ready(function () {
 			console.log(entry);
 			return '<a href value="' + entry + '" class="label label-' + labeltype + '">' + entry + '</a>';
 		}).join(' – ');
-		console.log(htm);
 		$(".nav-filter-" + mode).html(htm);
 		//toggle filter properties
 		$(".nav-filter-" + mode + " a").click(function (e) {
@@ -144,7 +143,6 @@ $(document).ready(function () {
 	$('#start').removeClass('hidden');
 
 	$('#default_entry').addClass('active');
-	console.log($('#default_entry'));
 
 	//expand/collapse filtersection
 	$(".nav-filter-toggle").click(function (e) {

--- a/js/daten.js
+++ b/js/daten.js
@@ -83,6 +83,16 @@ $(document).ready(function () {
 				entry.region.push($(e).text());
 			});
 
+			if (filter.years && entry.years.indexOf(filter.years) < 0) {
+				return;
+			}
+			if (filter.types && entry.types.indexOf(filter.types) < 0) {
+				return;
+			}
+			if (filter.licenses && entry.licenses.indexOf(filter.licenses) < 0) {
+				return;
+			}
+
 			if (entry.id !== 'start')
 				all_entries.push(entry);
 		});
@@ -108,7 +118,7 @@ $(document).ready(function () {
 			return 0;
 		});
 		var htm = list.map(function (entry) {
-			return '<a href value="' + entry + '" class="label label-' + labeltype + '">' + entry + '</a>';
+			return '<a href value="' + entry + '" class="label label-' + labeltype + (filter[mode] == entry ? ' active' : '') + '">' + entry + '</a>';
 		}).join(' – ');
 		$(".nav-filter-" + mode).html(htm);
 		//toggle filter properties
@@ -122,6 +132,11 @@ $(document).ready(function () {
 			if (val) {
 				$(e.currentTarget).addClass('active');
 			}
+			// rebuild filter list when changing filters
+			all_entries = [];
+			collectEntries();
+			mode != 'types' && fillFilter('types', 'info');
+			mode != 'licenses' && fillFilter('licenses', 'danger');
 			buildEntryList();
 			e.stopPropagation();
 			return false;

--- a/js/daten.js
+++ b/js/daten.js
@@ -1,8 +1,10 @@
 $(document).ready(function () {
-	if(!window.location.hash) {
-  		$('.data-entry').addClass('hidden');
-	}
-	
+	selectedId = window.location.hash ? window.location.hash.substr(1) : 'start';
+	$('.data-entry').map(function () {
+		if (this.id != selectedId) {
+			$(this).addClass('hidden');
+		}
+	});
 
 	var filter = {
 		category: null,
@@ -137,10 +139,6 @@ $(document).ready(function () {
 	//HACK: Set filter for 2015
 //	filter['years'] = '2015';
 	buildEntryList();
-
-
-	//show start
-	$('#start').removeClass('hidden');
 
 	$('#default_entry').addClass('active');
 

--- a/js/daten.js
+++ b/js/daten.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
 		category: null,
 		type: null,
 		license: null,
-		year: null
+		years: null
 	};
 	var all_entries = [];
 	var default_entry;
@@ -108,7 +108,6 @@ $(document).ready(function () {
 			return 0;
 		});
 		var htm = list.map(function (entry) {
-			console.log(entry);
 			return '<a href value="' + entry + '" class="label label-' + labeltype + '">' + entry + '</a>';
 		}).join(' – ');
 		$(".nav-filter-" + mode).html(htm);
@@ -130,11 +129,11 @@ $(document).ready(function () {
 	}
 
 	collectEntries();
-	fillFilter('categories', 'default');
+	//fillFilter('categories', 'default');
 	fillFilter('types', 'info');
 	fillFilter('licenses', 'danger');
 	fillFilter('years', 'warning');
-	fillFilter('region', 'primary');
+	//fillFilter('region', 'primary');
 	
 	//HACK: Set filter for 2015
 //	filter['years'] = '2015';

--- a/js/daten.js
+++ b/js/daten.js
@@ -1,17 +1,27 @@
 $(document).ready(function () {
-	selectedId = window.location.hash ? window.location.hash.substr(1) : 'start';
-	$('.data-entry').map(function () {
-		if (this.id != selectedId) {
-			$(this).addClass('hidden');
-		}
-	});
-
 	var filter = {
 		category: null,
 		type: null,
 		license: null,
 		years: null
 	};
+	var selectedId = 'start';
+	if (window.location.hash) {
+		if (window.location.hash.substr(0, 7) == '#event=') {
+			filter.years = decodeURI(window.location.hash.substr(7)).replace('-', ' ');
+			// upper case first char again
+			filter.years = filter.years[0].toUpperCase() + filter.years.substr(1);
+			console.log(filter);
+		} else {
+			selectedId = window.location.hash.substr(1);
+		}
+	}
+
+	$('.data-entry').map(function () {
+		if (this.id != selectedId) {
+			$(this).addClass('hidden');
+		}
+	});
 	var all_entries = [];
 	var default_entry;
 
@@ -138,6 +148,11 @@ $(document).ready(function () {
 			mode != 'types' && fillFilter('types', 'info');
 			mode != 'licenses' && fillFilter('licenses', 'danger');
 			buildEntryList();
+
+			if (mode == 'years') {
+				window.location.hash = val ? '#event=' + val.toLowerCase().replace(' ', '-') : '';
+			}
+
 			e.stopPropagation();
 			return false;
 		});

--- a/js/daten.js
+++ b/js/daten.js
@@ -16,6 +16,7 @@ $(document).ready(function () {
 	function scrollToAnchor(aid) {
 		var aTag = $("#" + aid);
 		$('html,body').animate({scrollTop: aTag.offset().top - 50}, 'slow');
+		window.location.hash = aid;
 	}
 
 	function buildEntryList() {


### PR DESCRIPTION
This PR allows users to link the datasets of single organisations or events of Coding da Vinci. Selecting a filter (e.g. year/event) automatically hides the combinations from types and licences which are no longer possible.

Examples URLs with filters:
* http://127.0.0.1:4000/daten/#stadtarchiv-speyer
* http://127.0.0.1:4000/daten/#event=süd-2019

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/40266/55841707-9baee900-5b30-11e9-9a69-9474374ab807.png">
